### PR TITLE
Include cmake package config on linux

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,3 +1,12 @@
-make all
-make check test-xxhsum-c namespaceTest
+#!/bin/sh
+
+mkdir build
+cd build
+
+cmake ../cmake_unofficial \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DBUILD_SHARED_LIBS=ON \
+      -DCMAKE_BUILD_TYPE=Release
+
+make -j ${CPU_COUNT}
 make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,6 +6,7 @@ cd build
 cmake ../cmake_unofficial \
       -DCMAKE_INSTALL_PREFIX=$PREFIX \
       -DBUILD_SHARED_LIBS=ON \
+      -DCMAKE_INSTALL_LIBDIR=lib \
       -DCMAKE_BUILD_TYPE=Release
 
 make -j ${CPU_COUNT}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,13 +12,13 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
     - {{ compiler('c') }}
     - make  # [unix]
-    - cmake  # [win]
+    - cmake 
 
 test:
   commands:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
this PR builds xxhash using the cmake build files on linux too (as on windows) and therefore generates cmake package configs which can be consumed by downstream libraries



Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->


<!--
Please add any other relevant info below:
-->
