### PR TITLE
Build Release configuration on Windows

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -4,5 +4,5 @@ cmake ../cmake_unofficial ^
       -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
       -DBUILD_SHARED_LIBS=ON ^
       -DCMAKE_BUILD_TYPE=Release
-cmake --build .
-cmake --build . --target install 
+cmake --build . --config Release
+cmake --build . --target install --config Release

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
As documented by @rwhitt2049 in conda-forge/python-xxhash-feedstock#15
the windows build of xxhash is a debug build and links against the
Windows Debug runtime which is not available on most machines.
It can also be seen from the Azure pipelines log[^1] that the recipe
builds the Debug configuration on Windows. According to the CMake
documentation[^2] specifying CMAKE_BUILD_TYPE has no effect on the
Visual Studio generator. Instead a StackOverflow post[^3] says to use
--config Release in the build command.

[^1]: https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=248039&view=logs&j=a70f640f-cc53-5cd3-6cdc-236a1aa90802&t=f5d15007-a01c-5ad8-c9ce-4d519d3b275f&l=403

[^2]: https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html

[^3]: https://stackoverflow.com/a/20423820

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
